### PR TITLE
Bump meilisearch-js to version 0.27.0-beta.1

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
     "firebase-admin": "^9.8.0",
     "firebase-functions": "^3.16.0",
     "inquirer": "^8.2.2",
-    "meilisearch": "^0.25.1"
+    "meilisearch": "^0.27.0-beta.1"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.15.0",

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -3773,10 +3773,10 @@ media-typer@0.3.0:
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-meilisearch@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.25.1.tgz#0dc25ffad64e6e50eb3da6c0691b0ff54f8578bf"
-  integrity sha512-20jO0pK9BhghxHSkOLbdoYn58h/Z0PNL3JQcRq7ipNIeqrxkAetCZZ6ttJC3uxcz0jVglmiFoSXu3Z/lEOLOLQ==
+meilisearch@^0.27.0-beta.1:
+  version "0.27.0-beta.1"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0-beta.1.tgz#62e64da55227f405e3f352a43e470947ac50f5ef"
+  integrity sha512-AnUnYKjpghPVC3zBXbF7QeikADfLyHl37aIcLS5xj+zqzku3ldQlOb9AbyBZ1gDhhWxrbltEgb0btmGyBv2jyQ==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
Update meilisearch-js version to latest beta to ensure tests are successful 