### PR TITLE
Pass firebase client agent to meilisearch-js

### DIFF
--- a/functions/__tests__/functions.test.ts
+++ b/functions/__tests__/functions.test.ts
@@ -5,6 +5,7 @@ import { mockConsoleLog, mockConsoleInfo } from './__mocks__/console'
 import { MeiliSearch } from 'meilisearch'
 import defaultEnvironment from './data/environment'
 import defaultDocument from './data/document'
+import { version } from '../src/version'
 
 jest.mock('meilisearch')
 
@@ -52,6 +53,7 @@ describe('extension', () => {
     expect(mockedMeilisearch).toHaveBeenCalledWith({
       apiKey: defaultEnvironment.MEILISEARCH_API_KEY,
       host: defaultEnvironment.MEILISEARCH_HOST,
+      clientAgents: [`Meilisearch Firebase (v${version})`],
     })
     expect(mockConsoleLog).toBeCalledWith(
       'Initializing extension with configuration',

--- a/functions/src/meilisearch/agents.ts
+++ b/functions/src/meilisearch/agents.ts
@@ -1,0 +1,9 @@
+import { version } from '../version'
+
+export const constructClientAgents = (
+  clientAgents: string[] = []
+): string[] => {
+  const firebaseAgent = `Meilisearch Firebase (v${version})`
+
+  return clientAgents.concat(firebaseAgent)
+}

--- a/functions/src/meilisearch/create-index.ts
+++ b/functions/src/meilisearch/create-index.ts
@@ -1,5 +1,6 @@
 import { MeiliSearch, Index } from 'meilisearch'
 import { MeilisearchConfig } from '../types'
+import { constructClientAgents } from './agents'
 
 /**
  * initMeilisearchIndex
@@ -14,6 +15,7 @@ export function initMeilisearchIndex({
   const client = new MeiliSearch({
     host,
     apiKey,
+    clientAgents: constructClientAgents(),
   })
 
   return client.index(indexUid)


### PR DESCRIPTION
See [related issue](https://github.com/meilisearch/integration-guides/issues/150)

This PR passes down the information of the firebase plugin package to the meilisearch-js package which in turn provided the information to meilisearch.