### PR TITLE
Update contributing guide to specify firebase tools version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,9 @@ To run this project, you will need:
 - Node >= 14 && node <= 17
 - Npm >= v7
 - A google account
-- Latest version of `firebase-tools` the Firebase CLI:
+- Version `v10.9.2` of `firebase-tools` the Firebase CLI (latest does not provide the emulator):
   ``` bash
-  yarn global add firebase-tools
+  yarn global add firebase-tools@10.9.2
   ```
   Add the directory for the commands of the packages installed globally in yarn, to access of firebase binary:
   ``` bash


### PR DESCRIPTION
Since the latest version of [firebase-tools v11.x.x](https://github.com/firebase/firebase-tools/releases/tag/v11.0.0) the emulator has been removed. 

To still be able to emulate a local environment with the extension, I suggest we keep the working version of firebase-tools