### PR TITLE
Update CI w/ node 18 compatibility / dependencies updates / beta CI

### DIFF
--- a/.github/scripts/beta-docker-version.sh
+++ b/.github/scripts/beta-docker-version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+package_json_version=$(grep '"version":' package.json | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
+beta_feature=$(echo $package_json_version | sed -r 's/[0-9]+.[0-9]+.[0-9]+-//')
+beta_feature=$(echo $beta_feature | sed -r 's/-beta\.[0-9]*$//')
+
+docker_image=$(curl https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags | jq | grep "$beta_feature" | head -1)
+docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
+echo $docker_image

--- a/.github/scripts/check-tag-format.sh
+++ b/.github/scripts/check-tag-format.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Checking if current tag matches the required formating
+is_pre_release=$1
+current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | tr -d ' ',v)
+
+if [ $is_pre_release = false ]; then
+  # Works with the format vX.X.X
+  #
+  # Example of correct format:
+  # v0.1.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*$"
+  if [ $? != 0 ]; then
+    echo "Error: Your tag: $current_tag is wrongly formatted."
+    echo 'Please refer to the contributing guide for help.'
+    exit 1
+  fi
+  exit 0
+elif [ $is_pre_release = true ]; then
+  # Works with the format vX.X.X-xxx-beta.X
+  # none or multiple -xxx are valid
+  #
+  # Examples of correct format:
+  # v0.1.0-beta.0
+  # v0.1.0-xxx-beta.0
+  # v0.1.0-xxx-xxx-beta.0
+  echo "$current_tag" | grep -E "[0-9]*\.[0-9]*\.[0-9]*-([a-z]*-)*beta\.[0-9]*$"
+
+  if [ $? != 0 ]; then
+    echo "Error: Your beta tag: $current_tag is wrongly formatted."
+    echo 'Please refer to the contributing guide for help.'
+    exit 1
+  fi
+  exit 0
+fi
+
+exit 0

--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Install dependencies

--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -1,0 +1,27 @@
+# Testing the code base against a specific Meilisearch feature
+name: Beta tests
+
+# Will only run for PRs and pushes to *-beta
+on:
+  push:
+    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+  pull_request:
+    branches: ['!bump-meilisearch-v*.*.*-beta', '**-beta']
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['14', '16', '18']
+    name: integration-tests (Node.js ${{ matrix.node }})
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn install:functions
+      - name: Run tests with coverage
+        run: yarn test:coverage

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Install dependencies

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,0 +1,27 @@
+# Testing the code base against the Meilisearch pre-releases
+name: Pre-Release Tests
+
+# Will only run for PRs and pushes to bump-meilisearch-v*
+on:
+  push:
+    branches: [bump-meilisearch-v*]
+  pull_request:
+    branches: [bump-meilisearch-v*]
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['14', '16', '18']
+    name: integration-tests (Node.js ${{ matrix.node }})
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn install:functions
+      - name: Run tests with coverage
+        run: yarn test:coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,47 +7,30 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
+      - name: Check tag format
+        run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
       - name: Install dependencies
         run: yarn && yarn install:functions
       - name: Copy README in the functions directory
         run: cp README.md functions/
       - name: Publish with latest tag
-        if: "!github.event.release.prerelease"
+        if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
         run: |
           cd functions
           npm publish .
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Publish with beta tag
-        if: "github.event.release.prerelease"
+        if: "github.event.release.prerelease && contains(github.ref, 'beta')"
         run: |
           cd functions
           npm publish . --tag beta
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-  publish-firestore:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@master
-      - name: Check release validity
-        run: sh .github/scripts/check-release.sh
-      - name: Install dependencies
-        run: yarn && yarn install:functions
-      - name: Copy README in the functions directory
-        run: cp README.md functions/
-      # We only publish in firestore in non-beta mode.
-      - name: Publish to Firestore
-        if: "!github.event.release.prerelease"
-        uses: w9jds/firebase-action@master
-        with:
-          args: ext:dev:publish meilisearch/firestore-meilisearch
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,28 +10,17 @@ on:
       - main
 
 jobs:
-  linter:
-    name: linter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-      - name: Install dependencies
-        run: yarn install:functions
-      - name: Run style check
-        run: yarn lint
-
   integration-tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: integration-tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["14", "16", "17"]
+        node: ['14', '16', '18']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -40,3 +29,16 @@ jobs:
         run: yarn install:functions
       - name: Run tests with coverage
         run: yarn test:coverage
+  style_tests:
+    runs-on: ubuntu-latest
+    name: style-check
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: yarn install:functions
+      - name: Run style check
+        run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
@@ -35,9 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Install dependencies
         run: yarn install:functions
       - name: Run style check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,7 @@ Here are the steps to release a beta version of this package:
       git checkout -b bump-meilisearch-v*.*.*-beta
       ```
 
-- Change the version in `package.json` with `*.*.*-xxx-beta.0` and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
+- Change the version in the relevant files (see how to publish the release section above) and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
   - `v*.*.*-my-feature-beta.0`
   - `v*.*.*-beta.0`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,18 +233,27 @@ firebase ext:dev:publish meilisearch/firestore-meilisearch
 
 #### Release a `beta` Version
 
-Here are the steps to release a beta version of this package **on `npm` not on the firebase store**:
+Here are the steps to release a beta version of this package:
 
-- Create a new branch originating the branch containing the "beta" changes. For example, if during the Meilisearch pre-release, create a branch originating `bump-meilisearch-v*.*.*`.<br>
-`vX.X.X` is the next version of the package, NOT the version of Meilisearch!
+- Create a new branch containing the "beta" changes with the following format `xxx-beta` where `xxx` explains the context.
 
-```bash
-git checkout bump-meilisearch-v*.*.*
-git pull origin bump-meilisearch-v*.*.*
-git checkout -b vX.X.X-beta.0
-```
+  For example:
+    - When implementing a beta feature, create a branch `my-feature-beta` where you implement the feature.
+      ```bash
+        git checkout -b my-feature-beta
+      ```
+    - During the Meilisearch pre-release, create a branch originating from `bump-meilisearch-v*.*.*` named `bump-meilisearch-v*.*.*-beta`. <br>
+    `v*.*.*` is the next version of the package, NOT the version of Meilisearch!
 
-- Update the versions following step 2 of the [`Publish the Release`](#publish-the-release) section. The version should be named: `vX.X.X-beta.0` and commit the files to the `vX.X.X-beta.0` branch.
+      ```bash
+      git checkout bump-meilisearch-v*.*.*
+      git pull origin bump-meilisearch-v*.*.*
+      git checkout -b bump-meilisearch-v*.*.*-beta
+      ```
+
+- Change the version in `package.json` with `*.*.*-xxx-beta.0` and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
+  - `v*.*.*-my-feature-beta.0`
+  - `v*.*.*-beta.0`
 
 - Go to the [GitHub interface for releasing](https://github.com/meilisearch/firestore-meilisearch/releases): on this page, click on `Draft a new release`.
 
@@ -256,7 +265,7 @@ git checkout -b vX.X.X-beta.0
   - ⚠️ Click on the "This is a pre-release" checkbox
   - Click on "Publish release"
 
-GitHub Actions will be triggered and push the beta version to [npm](https://www.npmjs.com/package/meilisearch).
+GitHub Actions will be triggered and push the beta version to [npm](https://www.npmjs.com/package/firestore-meilisearch).
 
 💡 If you need to release a new beta for the same version (i.e. `vX.X.X-beta.1`):
 - merge the change into `bump-meilisearch-v*.*.*`
@@ -264,9 +273,6 @@ GitHub Actions will be triggered and push the beta version to [npm](https://www.
 - change the version name in `package.json`
 - creata a pre-release via the GitHub interface
 
-<hr>
-
-Thank you again for reading this through, we can not wait to begin to work with you if you made your way through this contributing guide ❤️
 
 <hr>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,9 +251,7 @@ Here are the steps to release a beta version of this package:
       git checkout -b bump-meilisearch-v*.*.*-beta
       ```
 
-- Change the version in the relevant files (see how to publish the release section above) and commit it to the `v*.*.*-beta` branch. None or multiple `-xxx`are valid. Examples:
-  - `v*.*.*-my-feature-beta.0`
-  - `v*.*.*-beta.0`
+- Change the version in the relevant files (see how to publish the release section above) and commit it to the `beta` branch.
 
 - Go to the [GitHub interface for releasing](https://github.com/meilisearch/firestore-meilisearch/releases): on this page, click on `Draft a new release`.
 
@@ -270,7 +268,7 @@ GitHub Actions will be triggered and push the beta version to [npm](https://www.
 💡 If you need to release a new beta for the same version (i.e. `vX.X.X-beta.1`):
 - merge the change into `bump-meilisearch-v*.*.*`
 - rebase the `vX.X.X-beta.0` branch
-- change the version name in `package.json`
+- change the version name in the relevant files (see how to publish the release section above)
 - creata a pre-release via the GitHub interface
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ First of all, thank you for contributing to Meilisearch! The goal of this docume
 
 To run this project, you will need:
 
-- Node >= 14 && node <= 17
+- Node >= 14 && node <= 18
 - Npm >= v7
 - A google account
 - Version `v10.9.2` of `firebase-tools` the Firebase CLI (latest does not provide the emulator):

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-  'linter',
+  'style-check',
   'integration-tests (14)',
   'integration-tests (16)',
   'integration-tests (18)'

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@ status = [
   'linter',
   'integration-tests (14)',
   'integration-tests (16)',
-  'integration-tests (17)'
+  'integration-tests (18)'
 ]
 # 1 hour timeout
 timeout-sec = 3600


### PR DESCRIPTION
This PR adds:

- Ensure compatibility with node 18
- Adds the beta CI (with a file that is currently not used as no tests are done against Meilisearch)
- Updates the github action to their latest version

Updates are based on [instant-meilisearch CI's](https://github.com/meilisearch/instant-meilisearch/tree/main/.github)

fixes: #82 