### PR TITLE
Add explaination on tasks login in the post install file

### DIFF
--- a/POSTINSTALL.md
+++ b/POSTINSTALL.md
@@ -39,4 +39,4 @@ Learn more about using the import script to [backfill your existing collection](
 
 As a best practice, you can [monitor the activity](https://firebase.google.com/docs/extensions/manage-installed-extensions#monitor) of your installed extension, including checks on its health, usage, and logs.
 
-Nonetheless, Most of Meilisearch tasks are [asynchronous](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html#which-operations-are-async), meaning for example that errors on documents addition/deletion/... are not logged in your extensions logs. To access these logs, use the [tasks API](https://docs.meilisearch.com/reference/api/tasks.html).
+Nonetheless, most of Meilisearch tasks are [asynchronous](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html#which-operations-are-async), meaning, for example, that errors on document addition/deletion/update are not logged in your extensions logs. To access these logs, use the [tasks API](https://docs.meilisearch.com/reference/api/tasks.html).

--- a/POSTINSTALL.md
+++ b/POSTINSTALL.md
@@ -38,3 +38,5 @@ Learn more about using the import script to [backfill your existing collection](
 ### Monitoring
 
 As a best practice, you can [monitor the activity](https://firebase.google.com/docs/extensions/manage-installed-extensions#monitor) of your installed extension, including checks on its health, usage, and logs.
+
+Nonetheless, Most of Meilisearch tasks are [asynchronous](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html#which-operations-are-async), meaning for example that errors on documents addition/deletion/... are not logged in your extensions logs. To access these logs, use the [tasks API](https://docs.meilisearch.com/reference/api/tasks.html).


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #108

If a tasks fails inside Meilisearch, they are not logged into the extensions logs as they are asynchronous. Explaination on the matter had to be added in the post install documentation,