### PR TITLE
Add build of project in the publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check tag format
         run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
       - name: Install dependencies
-        run: yarn && yarn install:functions
+        run: yarn && yarn install:functions && yarn build
       - name: Copy README in the functions directory
         run: cp README.md functions/
       - name: Publish with latest tag


### PR DESCRIPTION
To ensure a safe-guard incase we forgot to add the builded files, we re-run the build before publishing to `npm`