### PR TITLE
Discard invalid _geo values

### DIFF
--- a/functions/__tests__/adapter.test.ts
+++ b/functions/__tests__/adapter.test.ts
@@ -102,5 +102,13 @@ describe('extensions process', () => {
         `A GeoPoint was found without the field name '_geo' if you want to use the geoSearch with Meilisearch rename it to '_geo'`
       )
     })
+    test('adaptValues with a _geo field at null', () => {
+      expect(
+        adaptFieldsForMeilisearch(
+          { _geo: null } as firestore.DocumentData,
+          '_geo'
+        )
+      ).toStrictEqual({})
+    })
   })
 })

--- a/functions/lib/meilisearch-adapter.js
+++ b/functions/lib/meilisearch-adapter.js
@@ -65,6 +65,9 @@ function adaptFieldsForMeilisearch(document, rawFieldsToIndex) {
                 (0, logs_1.infoGeoPoint)(false);
             }
         }
+        else if (currentField === '_geo') {
+            return doc;
+        }
         return { ...doc, [currentField]: value };
     }, {});
 }

--- a/functions/src/meilisearch-adapter.ts
+++ b/functions/src/meilisearch-adapter.ts
@@ -91,6 +91,8 @@ export function adaptFieldsForMeilisearch(
       } else {
         infoGeoPoint(false)
       }
+    } else if (currentField === '_geo') {
+      return doc
     }
     return { ...doc, [currentField]: value }
   }, {})


### PR DESCRIPTION
# Pull Request

## Related issue
One way to fix #160 

## What does this PR do?
- discards values for `_geo` filed that aren't GeoPoint - this usually means null values, but MeiliSearch will throw an error for any value that doesn't conform to the format, so this causes the extension to ignore any non-geopoint values for this field.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
