### PR TITLE
Add an allow list in the dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: 'npm'
-  directory: '/'
-  schedule:
-    interval: "monthly"
-    time: "04:00"
-  open-pull-requests-limit: 10
-  labels:
-  - skip-changelog
-  - dependencies
-  ignore:
-  - dependency-name: 'eslint*'
-  - dependency-name: 'prettier*'
-  rebase-strategy: disabled
-- package-ecosystem: github-actions
-  directory: '/functions'
-  schedule:
-    interval: "monthly"
-    time: "04:00"
-  labels:
-    - skip-changelog
-    - dependencies
+  - package-ecosystem: github-actions
+    directory: '/functions'
+    schedule:
+      interval: 'monthly'
+      time: '04:00'
+    labels:
+      - skip-changelog
+      - dependencies
+    allow:
+      - dependency-name: 'firebase-admin'
+      - dependency-name: 'firebase-functions'
+      - dependency-name: 'meilisearch'


### PR DESCRIPTION
Only the relevant packages should be updated regularly.
The packages that have been chosen are the ones that need regular updates to ensure staying compatible with the tools it uses: meilisearch and firebase