### PR TITLE
Add source directory

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -33,6 +33,8 @@ license: Apache-2.0 # https://spdx.org/licenses/
 # Public URL for the source code of your extension
 sourceUrl: https://github.com/meilisearch/firestore-meilisearch
 
+sourceDirectory: functions
+
 releaseNotesUrl: https://github.com/meilisearch/firestore-meilisearch/releases
 
 author:

--- a/functions/lib/import/index.js
+++ b/functions/lib/import/index.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-const admin = require("firebase-admin");
+const firebase_admin_1 = require("firebase-admin");
 const config_1 = require("./config");
 const logs = require("../logs");
 const meilisearch_adapter_1 = require("../meilisearch-adapter");
@@ -25,11 +25,11 @@ const run = async () => {
     // Retrieve all arguments from the commande line.
     const config = await (0, config_1.parseConfig)();
     // Initialize Firebase using the Google Credentials in the GOOGLE_APPLICATION_CREDENTIALS environment variable.
-    admin.initializeApp({
-        credential: admin.credential.applicationDefault(),
+    (0, firebase_admin_1.initializeApp)({
+        credential: firebase_admin_1.credential.applicationDefault(),
         databaseURL: `https://${config.projectId}.firebaseio.com`,
     });
-    const database = admin.firestore();
+    const database = (0, firebase_admin_1.firestore)();
     // Initialize Meilisearch index.
     const index = (0, create_index_1.initMeilisearchIndex)(config.meilisearch);
     await retrieveCollectionFromFirestore(database, config, index);


### PR DESCRIPTION
## why

Trying to fix the extension deployment and finally fix 
- #178
- #158

## how

Adding `sourceDirectory` in `extension.yaml` allowed me to deploy in local with:

```sh
firebase ext:dev:upload meilisearch/firestore-meilisearch --local
```

I'm hoping it will also work with the non-local, allowing me to deploy the updated version.

NB: running `npm run build` updated the `lib/*` file