### PR TITLE
Move typescript to dependencies

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,8 @@
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.1",
         "inquirer": "^8.2.2",
-        "meilisearch": "^0.30.0"
+        "meilisearch": "^0.30.0",
+        "typescript": "^4.4.3"
       },
       "bin": {
         "firestore-meilisearch": "lib/import/index.js"
@@ -36,8 +37,7 @@
         "mocked-env": "^1.3.5",
         "prettier": "^2.4.1",
         "ts-jest": "^29.0.5",
-        "ts-node": "^10.2.1",
-        "typescript": "^4.4.3"
+        "ts-node": "^10.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10833,7 +10833,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,8 @@
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^4.2.1",
     "inquirer": "^8.2.2",
-    "meilisearch": "^0.30.0"
+    "meilisearch": "^0.30.0",
+    "typescript": "^4.4.3"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.15.0",
@@ -46,8 +47,7 @@
     "mocked-env": "^1.3.5",
     "prettier": "^2.4.1",
     "ts-jest": "^29.0.5",
-    "ts-node": "^10.2.1",
-    "typescript": "^4.4.3"
+    "ts-node": "^10.2.1"
   },
   "bin": "lib/import/index.js"
 }


### PR DESCRIPTION
## why

- fix build to allow deploying v0.3.0

## how

- move `typescript` to dependencies

note: Google is unclear about it, but it seems that dev dependencies are not installed, as I see other projects including typescript as part of their dependencies (see [stripe-firebase-extensions](https://github.com/invertase/stripe-firebase-extensions/blob/next/firestore-stripe-invoices/functions/package.json))

```
firebase ext:dev:upload meilisearch/firestore-meilisearch

Extension: meilisearch/firestore-meilisearch
State: Published
Latest Version: 0.1.12
Version in Extensions Hub: 0.1.12
Source in GitHub: Local source

? Enter the GitHub repo URI where this extension's source code is located: https://github.com/meilisearch/firestore-meilisearch
? Enter this extension's root directory in the repo (defaults to previous root if set): /
? Enter the commit hash, branch, or tag name to build from in the repo: HEAD
Validating source code at https://github.com/meilisearch/firestore-meilisearch/tree/HEAD/...
? Choose the release stage: Stable (0.3.0, automatically sent for review)

You are about to upload a new version to Firebase's registry of extensions.

Extension: meilisearch/firestore-meilisearch
Version: 0.3.0 (automatically sent for review)
Source: https://github.com/meilisearch/firestore-meilisearch/tree/HEAD/
Release notes:
Breaking: Update nodejs runtime to node20 (#179) @brunoocasali

Once an extension version is uploaded, it becomes installable by other users and cannot be changed. If you wish to make changes after uploading, you will need to upload a new version.

? Do you wish to continue? Yes
✖ Uploading meilisearch/firestore-meilisearch@0.3.0...

Error: generic::invalid_argument: failed to build ExtensionVersion "publishers/meilisearch/extensions/firestore-meilisearch/versions/0.3.0" source: failed to build NPM package:
Pulling image: us-docker.pkg.dev/extensions-builder-prod/extensions-builder/builder
Using default tag: latest
latest: Pulling from extensions-builder-prod/extensions-builder/builder
3153aa388d02: Pulling fs layer
ef57089adb55: Pulling fs layer
792066ee936e: Pulling fs layer
9ed9b1b2bc55: Pulling fs layer
9ed9b1b2bc55: Waiting
3153aa388d02: Verifying Checksum
3153aa388d02: Download complete
9ed9b1b2bc55: Verifying Checksum
9ed9b1b2bc55: Download complete
ef57089adb55: Download complete
792066ee936e: Verifying Checksum
792066ee936e: Download complete
3153aa388d02: Pull complete
ef57089adb55: Pull complete
792066ee936e: Pull complete
9ed9b1b2bc55: Pull complete
Digest: sha256:3f9b4d6c7b66b5859a7d894cd23d8ddcf78a23dcee2959a79ef99a5c8c41b81b
Status: Downloaded newer image for us-docker.pkg.dev/extensions-builder-prod/extensions-builder/builder:latest
us-docker.pkg.dev/extensions-builder-prod/extensions-builder/builder:latest
Now using node v20.4.0 (npm v9.7.2)

> firestore-meilisearch@0.3.0 build
> tsc

sh: 1: tsc: not found
```