### PR TITLE
Remove jest types from tsconfig

### DIFF
--- a/functions/__tests__/adapter.test.ts
+++ b/functions/__tests__/adapter.test.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from '@jest/globals'
 import * as firebaseFunctionsTestInit from 'firebase-functions-test'
 import { mockConsoleInfo } from './__mocks__/console'
 import * as firestore from 'firebase-admin/firestore'

--- a/functions/__tests__/config.test.ts
+++ b/functions/__tests__/config.test.ts
@@ -1,3 +1,11 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals'
 import { readFileSync } from 'fs'
 import { resolve as pathResolve } from 'path'
 import * as yaml from 'js-yaml'

--- a/functions/__tests__/functions.test.ts
+++ b/functions/__tests__/functions.test.ts
@@ -57,6 +57,7 @@ describe('extension', () => {
   test('functions are exported', () => {
     const exportedFunctions = jest.requireActual('../src')
 
+    // @ts-ignore: We're asserting the export is a function
     expect(exportedFunctions.indexingWorker).toBeInstanceOf(Function)
   })
 

--- a/functions/__tests__/functions.test.ts
+++ b/functions/__tests__/functions.test.ts
@@ -1,3 +1,11 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals'
 import * as firebaseFunctionsTestInit from 'firebase-functions-test'
 import mockedEnv from 'mocked-env'
 import { mocked } from 'jest-mock'

--- a/functions/__tests__/tsconfig.json
+++ b/functions/__tests__/tsconfig.json
@@ -1,5 +1,15 @@
 {
   "extends": "../tsconfig.json",
-  "files": ["test.types.d.ts"],
-  "include": ["**/*"]
+  "compilerOptions": {
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "files": [
+    "test.types.d.ts"
+  ],
+  "include": [
+    "**/*"
+  ]
 }

--- a/functions/__tests__/util.test.ts
+++ b/functions/__tests__/util.test.ts
@@ -159,19 +159,19 @@ describe('getFieldsToIndex', () => {
   test('return empty list', () => {
     adapter = require('../src/meilisearch-adapter')
     mockParseFieldsToIndex = adapter.parseFieldsToIndex()
-    expect(mockParseFieldsToIndex).toMatchObject([])
+    expect(mockParseFieldsToIndex).toEqual([])
   })
 
   test('return list with one field', () => {
     adapter = require('../src/meilisearch-adapter')
     mockParseFieldsToIndex = adapter.parseFieldsToIndex('field')
-    expect(mockParseFieldsToIndex).toMatchObject(['field'])
+    expect(mockParseFieldsToIndex).toEqual(['field'])
   })
 
   test('return list with multiple fields', () => {
     adapter = require('../src/meilisearch-adapter')
     mockParseFieldsToIndex = adapter.parseFieldsToIndex('field1,field2,field3')
-    expect(mockParseFieldsToIndex).toMatchObject(['field1', 'field2', 'field3'])
+    expect(mockParseFieldsToIndex).toEqual(['field1', 'field2', 'field3'])
   })
 
   test('return list with multiple fields and spaces', () => {
@@ -179,7 +179,7 @@ describe('getFieldsToIndex', () => {
     mockParseFieldsToIndex = adapter.parseFieldsToIndex(
       'field1, field2,  field3'
     )
-    expect(mockParseFieldsToIndex).toMatchObject(['field1', 'field2', 'field3'])
+    expect(mockParseFieldsToIndex).toEqual(['field1', 'field2', 'field3'])
   })
 
   test('return list of fiels with underscore', () => {
@@ -187,10 +187,6 @@ describe('getFieldsToIndex', () => {
     mockParseFieldsToIndex = adapter.parseFieldsToIndex(
       'field_1,field_2,field_3'
     )
-    expect(mockParseFieldsToIndex).toMatchObject([
-      'field_1',
-      'field_2',
-      'field_3',
-    ])
+    expect(mockParseFieldsToIndex).toEqual(['field_1', 'field_2', 'field_3'])
   })
 })

--- a/functions/__tests__/util.test.ts
+++ b/functions/__tests__/util.test.ts
@@ -1,3 +1,11 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from '@jest/globals'
 import * as firebaseFunctionsTestInit from 'firebase-functions-test'
 import mockedEnv from 'mocked-env'
 import { ChangeType, getChangedDocumentId, getChangeType } from '../src/util'

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.15.0",
+        "@jest/globals": "^29.7.0",
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "^4.32.0",
         "@typescript-eslint/parser": "^4.32.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.15.0",
+    "@jest/globals": "^29.7.0",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -9,7 +9,6 @@
     "strict": true,
     "target": "es2018",
     "types": [
-      "jest",
       "node",
     ]
   },
@@ -19,5 +18,6 @@
   ],
   "exclude": [
     "node_modules",
+    "**/__tests__/**"
   ]
 }


### PR DESCRIPTION
# Pull Request

## Related issue

Error when publishing the extension

```

Extension: meilisearch/firestore-meilisearch
State: Published
Latest Version: 0.1.12
Version in Extensions Hub: 0.1.12
Source in GitHub: Local source

? Enter the GitHub repo URI where this extension's source code is located: https://github.com/meilisearch/firestore-meilisearch
? Enter this extension's root directory in the repo (defaults to previous root if set): /
? Enter the commit hash, branch, or tag name to build from in the repo: HEAD
Validating source code at https://github.com/meilisearch/firestore-meilisearch/tree/HEAD/...
? Choose the release stage: Stable (0.3.0, automatically sent for review)

You are about to upload a new version to Firebase's registry of extensions.

Extension: meilisearch/firestore-meilisearch
Version: 0.3.0 (automatically sent for review)
Source: https://github.com/meilisearch/firestore-meilisearch/tree/HEAD/
Release notes:
Breaking: Update nodejs runtime to node20 (#179) @brunoocasali

Once an extension version is uploaded, it becomes installable by other users and cannot be changed. If you wish to make changes after uploading, you will need to upload a new version.

? Do you wish to continue? Yes
✖ Uploading meilisearch/firestore-meilisearch@0.3.0...

Error: generic::invalid_argument: failed to build ExtensionVersion "publishers/meilisearch/extensions/firestore-meilisearch/versions/0.3.0" source: failed to build NPM package:
Pulling image: us-docker.pkg.dev/extensions-builder-prod/extensions-builder/builder
Using default tag: latest
latest: Pulling from extensions-builder-prod/extensions-builder/builder
3153aa388d02: Pulling fs layer
ef57089adb55: Pulling fs layer
792066ee936e: Pulling fs layer
9ed9b1b2bc55: Pulling fs layer
9ed9b1b2bc55: Waiting
3153aa388d02: Verifying Checksum
3153aa388d02: Download complete
9ed9b1b2bc55: Verifying Checksum
9ed9b1b2bc55: Download complete
ef57089adb55: Download complete
792066ee936e: Verifying Checksum
792066ee936e: Download complete
3153aa388d02: Pull complete
ef57089adb55: Pull complete
792066ee936e: Pull complete
9ed9b1b2bc55: Pull complete
Digest: sha256:3f9b4d6c7b66b5859a7d894cd23d8ddcf78a23dcee2959a79ef99a5c8c41b81b
Status: Downloaded newer image for us-docker.pkg.dev/extensions-builder-prod/extensions-builder/builder:latest
us-docker.pkg.dev/extensions-builder-prod/extensions-builder/builder:latest
Now using node v20.4.0 (npm v9.7.2)

> firestore-meilisearch@0.3.0 build
> tsc

error TS2688: Cannot find type definition file for 'jest'.
  The file is in the program because:
    Entry point of type library 'jest' specified in compilerOptions
```

## What does this PR do?
- Move `jest` types to `functions/__tests__/tsconfig.json`
- Fix ensuing type errors

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
